### PR TITLE
Make doc list-concatenation more clear as for += and extend().

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -303,7 +303,9 @@ List concatenation ~
 							*list-concatenation*
 Two lists can be concatenated with the "+" operator: >
 	:let longlist = mylist + [5, 6]
+A list can be concatenated with another one in place using the "+=" operator or |extend()|: >
 	:let mylist += [7, 8]
+	:call extend(mylist, [7, 8])
 
 To prepend or append an item, turn the item into a list by putting [] around
 it.  To change a list in-place, refer to |list-modification| below.


### PR DESCRIPTION
1. describe `+=` for list-concatenation more accurately
2. add `extend()` example for list-concatenation